### PR TITLE
[BACK-905] Refactor routes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.3
+* BACK-905: Refactor routes.
+
 ## 0.0.2 (2015-09-25)
 * BACK-938: Renew expired tokens.
 * Updated dependencies.

--- a/cmd/config.coffee
+++ b/cmd/config.coffee
@@ -34,7 +34,7 @@ module.exports = configure = (argv..., cb) ->
     (next) -> project.setup options, next
   ], (err) ->
     if err? # Display errors.
-      logger.error "%s", err
+      logger.error '%s', err
       unless cb? then process.exit -1 # Exit with error.
     cb? err
 

--- a/cmd/deploy.coffee
+++ b/cmd/deploy.coffee
@@ -39,7 +39,7 @@ module.exports = deploy = (argv..., cb) ->
     (version, next) -> datalink.deploy process.cwd(), version, next
   ], (err) ->
     if err? # Display errors.
-      logger.error "%s", err
+      logger.error '%s', err
       unless cb? then process.exit -1 # Exit with error.
     cb? err
 

--- a/cmd/list.coffee
+++ b/cmd/list.coffee
@@ -37,7 +37,7 @@ module.exports = list = (argv..., cb) ->
     project.list
   ], (err) ->
     if err? # Display errors.
-      logger.error "%s", err
+      logger.error '%s', err
       unless cb? then process.exit -1 # Exit with error.
     cb? err
 

--- a/cmd/recycle.coffee
+++ b/cmd/recycle.coffee
@@ -38,7 +38,7 @@ module.exports = recycle = (argv..., cb) ->
     datalink.recycle
   ], (err) ->
     if err? # Display errors.
-      logger.error "%s", err
+      logger.error '%s', err
       unless cb? then process.exit -1 # Exit with error.
     cb? err
 

--- a/cmd/status.coffee
+++ b/cmd/status.coffee
@@ -38,7 +38,7 @@ module.exports = status = (job, command, cb) ->
     (next) -> datalink.status job, next
   ], (err) ->
     if err? # Display errors.
-      logger.error "%s", err
+      logger.error '%s', err
       unless cb? then process.exit -1 # Exit with error.
     cb? err
 

--- a/lib/datalink.coffee
+++ b/lib/datalink.coffee
@@ -50,8 +50,8 @@ class Datalink
       url      : "/v#{project.schemaVersion}/jobs"
       headers  : { 'Transfer-Encoding': 'chunked' }
       formData : {
-        type   : 'deploy'
-        params : JSON.stringify { app: project.app, dlc: project.datalink, version: version }
+        type   : 'deployDataLink'
+        params : JSON.stringify { appId: project.app, dataLinkId: project.datalink, version: version }
         file   : attachment
       },
       timeout  : config.uploadTimeout or 30 * 1000 # 30s.
@@ -123,8 +123,8 @@ class Datalink
       method : 'POST'
       url    : "/v#{project.schemaVersion}/jobs"
       body   : {
-        type   : 'recycle'
-        params : { app: project.app, dlc: project.datalink }
+        type   : 'recycleDataLink'
+        params : { appId: project.app, dataLinkId: project.datalink }
       }
     }, cb
 

--- a/lib/datalink.coffee
+++ b/lib/datalink.coffee
@@ -47,9 +47,13 @@ class Datalink
     # Prepare the request.
     req = util.makeRequest {
       method   : 'POST'
-      url      : "/v#{project.schemaVersion}/apps/#{project.app}/data-links/#{project.datalink}/deploy"
-      headers  : { 'Transfer-Encoding': 'chunked' },
-      formData : { version: version, file: attachment }
+      url      : "/v#{project.schemaVersion}/jobs"
+      headers  : { 'Transfer-Encoding': 'chunked' }
+      formData : {
+        type   : 'deploy'
+        params : JSON.stringify { app: project.app, dlc: project.datalink, version: version }
+        file   : attachment
+      },
       timeout  : config.uploadTimeout or 30 * 1000 # 30s.
     }, (err, response) ->
       if err? then req.emit 'error', err # Trigger request error.
@@ -116,15 +120,17 @@ class Datalink
   # Executes a POST /apps/:app/datalink/:datalink/recycle request.
   _execRecycle: (cb) ->
     util.makeRequest {
-      method : 'POST',
-      url    : "/v#{project.schemaVersion}/apps/#{project.app}/data-links/#{project.datalink}/recycle"
+      method : 'POST'
+      url    : "/v#{project.schemaVersion}/jobs"
+      body   : {
+        type   : 'recycle'
+        params : { app: project.app, dlc: project.datalink }
+      }
     }, cb
 
   # Executes a GET /apps/:app/datalink/:datalink/<type> request.
   _execStatus: (job, cb) ->
-    util.makeRequest {
-      url: "/v#{project.schemaVersion}/apps/#{project.app}/data-links/#{project.datalink}/deploy?job=#{job}"
-    }, cb
+    util.makeRequest { url: "/v#{project.schemaVersion}/jobs/#{job}" }, cb
 
   # Returns true if the provided path is an artifact.
   _isArtifact: (base, filepath) ->

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -51,7 +51,7 @@ class Project
         datalinks.forEach (datalink) =>
           # Highlight the active datalink.
           bullet = if datalink.id is this.datalink then chalk.green '* ' else ''
-          logger.info '%s%s (%s)', bullet, chalk.cyan(datalink.name), datalink.host
+          logger.info '%s%s', bullet, chalk.cyan(datalink.name)
         logger.info 'The datalink used in this project is marked with *'
         cb() # Continue.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name"         : "kinvey-dlc-cli",
-  "version"      : "0.0.2",
+  "version"      : "0.0.3",
   "description"  : "Utility for deploying Kinvey DLC microservices to Kinvey’s Node DLC PaaS.",
   "keywords"     : [ "Kinvey" ],
   "homepage"     : "http://www.kinvey.com",

--- a/test/datalink.coffee
+++ b/test/datalink.coffee
@@ -46,7 +46,7 @@ describe 'datalink', () ->
       beforeEach 'api', () ->
         this.subject = null
         this.mock = api
-          .post "/v1/apps/#{project.app}/data-links/#{project.datalink}/deploy"
+          .post '/v1/jobs'
           .reply 202, (uri, requestBody) =>
             this.subject = requestBody
 
@@ -82,7 +82,7 @@ describe 'datalink', () ->
       beforeEach 'api', () ->
         this.subject = null
         this.mock = api
-          .post "/v2/apps/#{project.app}/data-links/#{project.datalink}/deploy"
+          .post '/v2/jobs'
           .reply 202, (uri, requestBody) =>
             this.subject = requestBody
 
@@ -122,7 +122,7 @@ describe 'datalink', () ->
 
       # Mock the API.
       beforeEach 'api', () ->
-        this.mock = api.post "/v1/apps/#{project.app}/data-links/#{project.datalink}/recycle"
+        this.mock = api.post '/v1/jobs'
           .reply 202, { job: 123 }
       afterEach 'api', () ->
         this.mock.done()
@@ -139,7 +139,7 @@ describe 'datalink', () ->
 
       # Mock the API.
       beforeEach 'api', () ->
-        this.mock = api.post "/v2/apps/#{project.app}/data-links/#{project.datalink}/recycle"
+        this.mock = api.post '/v2/jobs'
           .reply 202, { job: 123 }
       afterEach 'api', () ->
         this.mock.done()
@@ -162,7 +162,7 @@ describe 'datalink', () ->
 
       # Mock the API.
       beforeEach 'api', () ->
-        this.mock = api.get "/v1/apps/#{project.app}/data-links/#{project.datalink}/deploy?job=123"
+        this.mock = api.get '/v1/jobs/123'
           .reply 200, { status: 'COMPLETE' }
       afterEach 'api', () ->
         this.mock.done()
@@ -182,7 +182,7 @@ describe 'datalink', () ->
 
       # Mock the API.
       beforeEach 'api', () ->
-        this.mock = api.get "/v2/apps/#{project.app}/data-links/#{project.datalink}/deploy?job=123"
+        this.mock = api.get '/v2/jobs/123'
           .reply 200, { status: 'COMPLETE' }
       afterEach 'api', () ->
         this.mock.done()


### PR DESCRIPTION
Updates deploy, recycle, and status routes to use MAPI /jobs endpoint.

NOTE: Make sure release of MAPI is timed with npm publish of dlc-cli.