### PR TITLE
BACK-1307: DLC error handling

### DIFF
--- a/lib/datalink.coffee
+++ b/lib/datalink.coffee
@@ -135,6 +135,7 @@ class Datalink
       if err? then cb err # Continue with error.
       else # OK.
         logger.info 'Job status: %s %s', chalk.cyan(response.body.status), response.body.message or ''
+        if response.body.error? then logger.info 'Error:', chalk.cyan response.body.error
         cb null, response.body.status # Continue.
 
   # Validates the project.

--- a/lib/datalink.coffee
+++ b/lib/datalink.coffee
@@ -134,8 +134,7 @@ class Datalink
     this._execStatus job, (err, response) ->
       if err? then cb err # Continue with error.
       else # OK.
-        logger.info 'Job status: %s %s', chalk.cyan(response.body.status), response.body.message or ''
-        if response.body.error? then logger.info 'Error:', chalk.cyan response.body.error
+        logger.info 'Job status: %s - %s', chalk.cyan(response.body.status), response.body.progress or ''
         cb null, response.body.status # Continue.
 
   # Validates the project.


### PR DESCRIPTION
When retrieving a deploy status, display the latest progress message together with the status. This will also cause error messages to be displayed whenever a task is marked as `FAILED`.