### PR TITLE
BACK-1325: Handle authentication errors when deploying.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.0.7
+* BACK-1325: Handle authentication errors when deploying.
+
 ## 0.0.6 (2016-03-17)
 * BACK-1358: Do not display progress message for completed jobs.
 

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -58,9 +58,6 @@ exports.makeRequest = makeRequest = (options, cb) ->
     options.headers ?= { }
     options.headers?.Authorization = "Kinvey #{user.token}"
 
-
-#  console.log require('util').inspect options, { showHidden: true, depth: 5 }
-
   # Perform the request.
   logger.debug 'Request:  %s %s', options.method, options.url
   request.Request options, (err, response) ->

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kinvey-dlc-cli",
-  "version": "0.0.6",
+  "version": "0.0.7-dev",
   "description": "Utility for deploying Kinvey DLC microservices to Kinvey’s Node DLC PaaS.",
   "keywords": [
     "Kinvey"


### PR DESCRIPTION
This PR fixes a bug in the deploy functionality where deploying would fail if the user was not authenticated properly. Due to the project package being pipe-d into the request, the default retry functionality did not work properly. The changes here manually handle authentication errors, so retrying a deploy actually works.