### PR TITLE
BACK-1912: Kinvey CLI usability enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,15 @@
 In your project directory, run `kinvey-cli config` to set-up your project. The CLI will prompt for Kinvey credentials, app, and Data Link.
 
 ### Commands
-* `config` - set project options.
+* `config [host]` - set project options (including optional host if using a dedicated Kinvey instance)
 * `deploy` - deploy the current project as a Kinvey-backed Data Link Connector. You can check the status of a deploy using the `job` command (more info below).
-* `status` - display the health of the configured KMR service
+* `status` - display the health status of a Kinvey service
 * `help` - display usage information.
 * `list` - list the configured Kinvey-backed Data Link Connectors for the current app.
 * `logs` - query logs for this Kinvey-backed Data Link Connector.
   * Logs are displayed in the following format: `<runtime id> <timestamp> - <message>`
   * E.g. `ac7df839104d 2016-02-23T20:00:29.334Z - hello world`
+* `logout` - clears Kinvey session data and project settings
 * `job <id>` - return the status of a `deploy` command.
 
 ### Options
@@ -26,8 +27,10 @@ In your project directory, run `kinvey-cli config` to set-up your project. The C
 * `-c, --suppress-version-check` - do not check for package updates.
 * `-v, --verbose` - output debug messages.
 
+The Kinvey CLI supports one-time session creation using the `-e`, `-p`, and (and optionally `--host`) flags. Set these parameters explicitly in your calls if you are unable to init with `kinvey-cli config`.
+
 ## Troubleshooting
-Run any command with the `--verbose` flag to see what is going on when executing a command. If problems persist, please contact [Kinvey](http://support.kinvey.com). In any case, make sure you have configured your project using the `config` command before attempting to execute any other commands.
+Run any command with the `-v` (`--verbose`) flag to see what is going on when executing a command. If problems persist, please contact [Kinvey](http://support.kinvey.com). In any case, make sure you have configured your project using the `config` command before attempting to execute any other commands.
 
 ## Changelog
 See the [Changelog](./CHANGELOG.md) for a list of changes.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ In your project directory, run `kinvey-cli config` to set-up your project. The C
 * `-c, --suppress-version-check` - do not check for package updates.
 * `-v, --verbose` - output debug messages.
 
-The Kinvey CLI supports one-time session creation using the `-e`, `-p`, and (and optionally `--host`) flags. Set these parameters explicitly in your calls if you are unable to init with `kinvey-cli config`.
+The Kinvey CLI supports one-time session creation using the `-e` and `-p` (and optionally `--host`) flags. Set these parameters explicitly in your calls if you are unable to init with `kinvey-cli config`.
 
 ## Troubleshooting
 Run any command with the `-v` (`--verbose`) flag to see what is going on when executing a command. If problems persist, please contact [Kinvey](http://support.kinvey.com). In any case, make sure you have configured your project using the `config` command before attempting to execute any other commands.

--- a/bin/cli.coffee
+++ b/bin/cli.coffee
@@ -42,6 +42,7 @@ module.exports = (args) ->
   require '../cmd/config.coffee'
   require '../cmd/deploy.coffee'
   require '../cmd/list.coffee'
+  require '../cmd/logout.coffee'
   require '../cmd/logs.coffee'
   require '../cmd/recycle.coffee'
   require '../cmd/status.coffee'

--- a/cmd/logout.coffee
+++ b/cmd/logout.coffee
@@ -16,7 +16,6 @@ limitations under the License.
 
 # Package modules.
 async   = require 'async'
-chalk   = require 'chalk'
 program = require 'commander'
 
 # Local modules.
@@ -24,22 +23,16 @@ init    = require '../lib/init.coffee'
 logger  = require '../lib/logger.coffee'
 project = require '../lib/project.coffee'
 user    = require '../lib/user.coffee'
-util    = require '../lib/util.coffee'
 
 # Entry point for the config command.
-module.exports = configure = (host, command, cb) ->
-  options = init command # Initialize the command.
+module.exports = logout = (argv..., cb) ->
+  options = init this # Initialize the command.
 
-  # If host is specified here then set it as the base URL and save it for future requests
-  if host? # Format and adjust host.
-    baasHost = util.formatHost host
-    logger.debug 'Setting host of the Kinvey service to %s', chalk.cyan baasHost
-    user.host = baasHost
-
-  # Set-up user and project.
+  # Clear sessions and project settings
   async.series [
-    (next) -> user.setup     options, next
-    (next) -> project.config options, next
+    # Log out user.
+    (next) -> user.logout    next
+    (next) -> project.logout next
   ], (err) ->
     if err? # Display errors.
       logger.error '%s', err
@@ -48,6 +41,6 @@ module.exports = configure = (host, command, cb) ->
 
 # Register the command.
 program
-  .command     'config [host]'
-  .description 'set project options, including optional Kinvey host (if using a dedicated instance)'
-  .action      configure
+.command     'logout'
+.description 'resets host, removes sessions, and clears project settings'
+.action      logout

--- a/config/default.coffee
+++ b/config/default.coffee
@@ -22,7 +22,7 @@ osHomedir = require 'os-homedir'
 
 # Exports.
 module.exports =
-  host: 'https://manage.kinvey.com'
+  host: 'https://manage.kinvey.com/'
 
   # Default schema for apps.
   defaultSchemaVersion: 2

--- a/lib/init.coffee
+++ b/lib/init.coffee
@@ -15,15 +15,12 @@ limitations under the License.
 ###
 
 # Package modules.
-chalk          = require 'chalk'
 lodashMerge    = require 'lodash.merge'
 updateNotifier = require 'update-notifier'
 
 # Local modules.
 logger  = require './logger.coffee'
 pkg     = require '../package.json'
-request = require './request.coffee'
-util    = require './util.coffee'
 
 # Exports.
 module.exports = (command) ->
@@ -33,10 +30,6 @@ module.exports = (command) ->
   # Shared options.
   if options.silent  then logger.config { level: 3 }
   if options.verbose then logger.config { level: 0 }
-  if options.host? # Format and adjust host.
-    host = util.formatHost options.host
-    logger.debug 'Setting host of the Kinvey service to %s', chalk.cyan host
-    request.Request = request.Request.defaults { baseUrl: host } # Save.
 
   # Check for updates.
   unless options.suppressVersionCheck

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -31,14 +31,18 @@ class Project
 
   # App, service, and schema.
   app           : null
-  service      : null
-  serviceName  : null
+  service       : null
+  serviceName   : null
   schemaVersion : null
   lastJobId     : null
 
   # Constructor.
   constructor: (path) ->
     this.projectPath = path
+
+  # Configures the project.
+  config: (options, cb) =>
+    this.select cb
 
   # Returns whether the project is configured.
   isConfigured: () =>
@@ -56,6 +60,11 @@ class Project
           logger.info '%s%s', bullet, chalk.cyan(service.name)
         logger.info 'The service used in this project is marked with *'
         cb() # Continue.
+
+  logout: (cb) =>
+    logger.debug 'Clearing project configuration from file %s', chalk.cyan this.projectPath
+    logger.info "Logout complete. Run 'kinvey config' to get started."
+    util.writeJSON this.projectPath, '', cb
 
   # Restores the project from file.
   restore: (cb) =>
@@ -99,10 +108,6 @@ class Project
       if !this.isConfigured() # Not configured, prompt for details.
         this.select cb
       else cb err # Continue.
-
-  # Configures the project.
-  config: (options, cb) =>
-    this.select cb
 
   # Executes a GET /apps request.
   _execApps: (cb) ->

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -56,7 +56,7 @@ exports.makeRequest = makeRequest = (options, cb) ->
   options.method ?= 'GET' # Default to GET.
   if user.isLoggedIn()
     options.headers ?= { }
-    options.headers?.Authorization = "Kinvey #{user.token}"
+    options.headers?.Authorization = "Kinvey #{user.getToken()}"
 
   # Perform the request.
   logger.debug 'Request:  %s %s', options.method, options.url

--- a/test/cli.coffee
+++ b/test/cli.coffee
@@ -43,17 +43,6 @@ describe "./#{pkg.name}", () ->
   after     'stub', () -> logger.config.restore()
 
   # Test global options.
-  describe '--host <host>', () ->
-    # Stub request.Request.defaults().
-    before    'stub', () -> sinon.spy request.Request, 'defaults'
-    afterEach 'stub', () -> request.Request.defaults.reset()
-    after     'stub', () -> request.Request.defaults.restore()
-
-    it 'should set the host of the Kinvey service.', () ->
-      cli [ 'node', pkg.name, 'test', '--host', 'example.com' ]
-      expect(request.Request.defaults).to.be.calledOnce
-      expect(request.Request.defaults).to.be.calledWith { baseUrl: 'https://example.com' }
-
   describe '-s, --silent', () ->
     it 'should not output anything.', () ->
       cli [ 'node', pkg.name, 'test', '--silent' ]

--- a/test/config.coffee
+++ b/test/config.coffee
@@ -19,13 +19,14 @@ sinon = require 'sinon'
 
 # Local modules.
 command = require './fixtures/command.coffee'
-config  = require '../cmd/config.coffee'
 pkg     = require '../package.json'
 project = require '../lib/project.coffee'
 user    = require '../lib/user.coffee'
 
 # Test suite.
 describe "./#{pkg.name} config", () ->
+  beforeEach () -> this.config  = require '../cmd/config.coffee'
+
   # Stub user.setup().
   before    'user', () -> sinon.stub(user, 'setup').callsArg 1
   afterEach 'user', () -> user.setup.reset()
@@ -38,11 +39,19 @@ describe "./#{pkg.name} config", () ->
 
   # Tests.
   it 'should setup the user.', (cb) ->
-    config.call command, (err) ->
+    this.config null, command, (err) ->
       expect(user.setup).to.be.calledOnce
       cb err
 
-  it 'should config the project.', (cb) ->
-    config.call command, (err) ->
+  it 'configure the project with the default host.', (cb) ->
+    this.config null, command, (err) ->
       expect(project.config).to.be.calledOnce
+      expect(user.host).to.be.null
+      cb err
+
+  it 'configure the project with a custom host.', (cb) ->
+    host = '123'
+    this.config host, command, (err) ->
+      expect(project.config).to.be.calledOnce
+      expect(user.host).to.equal 'https://' + host
       cb err

--- a/test/logout.coffee
+++ b/test/logout.coffee
@@ -1,0 +1,48 @@
+###
+Copyright 2016 Kinvey, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+###
+
+# Package modules.
+sinon = require 'sinon'
+
+# Local modules.
+command = require './fixtures/command.coffee'
+logout  = require '../cmd/logout.coffee'
+pkg     = require '../package.json'
+project = require '../lib/project.coffee'
+user    = require '../lib/user.coffee'
+
+# Test suite.
+describe "./#{pkg.name} logout", () ->
+  # Stub user.setup().
+  before    'user', () -> sinon.stub(user, 'logout').callsArg 0
+  afterEach 'user', () -> user.logout.reset()
+  after     'user', () -> user.logout.restore()
+
+  # Stub project.logout().
+  before    'project', () -> sinon.stub(project, 'logout').callsArg 0
+  afterEach 'project', () -> project.logout.reset()
+  after     'project', () -> project.logout.restore()
+
+  # Tests.
+  it 'should logout the user.', (cb) ->
+    logout.call command, (err) ->
+      expect(user.logout).to.be.calledOnce
+      cb err
+
+  it 'should logout the project.', (cb) ->
+    logout.call command, (err) ->
+      expect(project.logout).to.be.calledOnce
+      cb err

--- a/test/logs.coffee
+++ b/test/logs.coffee
@@ -27,7 +27,7 @@ user     = require '../lib/user.coffee'
 
 # Test suite.
 describe "./#{pkg.name} logs", () ->
-# Stub user.setup().
+  # Stub user.setup().
   before    'user', () -> sinon.stub(user, 'setup').callsArg 1
   afterEach 'user', () -> user.setup.reset()
   after     'user', () -> user.setup.restore()

--- a/test/project.coffee
+++ b/test/project.coffee
@@ -88,6 +88,29 @@ describe 'project', () ->
           expect(logger.info).to.be.calledWith 'The service used in this project is marked with *'
           cb err
 
+  # project.logout().
+  describe 'logout', () ->
+    # Configure.
+    beforeEach 'configure', () -> project.app = project.service = '123'
+    afterEach  'configure', () -> project.app = project.service = null # Reset.
+
+    # Stub.
+    before    'stub', -> sinon.stub logger, 'info'
+    afterEach 'stub', -> logger.info.reset()
+    after     'stub', -> logger.info.restore()
+
+    describe 'for v2 apps', ->
+      # Configure.
+      beforeEach 'configure', () -> project.schemaVersion = 2
+      afterEach  'configure', () -> project.schemaVersion = null # Reset.
+
+      # Tests.
+      it 'should log out the user', (cb) ->
+        project.logout (err) ->
+          expect(logger.info).to.be.called
+          expect(logger.info).to.be.calledWith "Logout complete. Run 'kinvey config' to get started."
+          cb err
+
   # project.restore()
   describe 'restore', () ->
     describe 'when the project file exists', () ->
@@ -222,7 +245,6 @@ describe 'project', () ->
       # Tests.
       it 'should select the app and service to use.', (cb) ->
         project.select (err) ->
-          console.log require('util').inspect err
           expect(prompt.getApp).to.be.calledOnce
           expect(prompt.getApp).to.be.calledWith [ fixtures.app ]
           expect(prompt.getService).to.be.calledOnce


### PR DESCRIPTION
*`host` is no longer manually required on a per-call basis when the CLI is initialized via  `config [host]`
*Added `logout` command to easily clear session and project data
*Kinvey CLI now supports persistent tokens for multiple hosts. Users are only re-prompted for credentials when tokens expire or when logging into a new host for the first time
*The default host (manage.kinvey.com) is used when `-e` and `-p` are specified without a corresponding `--host` arg

... plus tests