### PR TITLE
BACK-2022: Update 'invalid package' error message to use 'kinvey-flex…

### DIFF
--- a/lib/error.coffee
+++ b/lib/error.coffee
@@ -24,7 +24,7 @@ pkg    = require '../package.json'
 # Enumerate errors.
 errors =
   InvalidProject:
-    message: 'This project is not valid. Please implement the kinvey-backend-sdk node module.'
+    message: 'This project is not valid. Please implement the kinvey-flex-sdk node module.'
   ProjectNotConfigured:
     message: "This project is not configured. Use `#{pkg.name} config` to get started."
   ProjectMaxFileSizeExceeded:


### PR DESCRIPTION
…-sdk' instead of 'kinvey-backend-sdk