### PR TITLE
BACK-1934: Obfuscate Kinvey MAPI URLs. Plus tests.

### DIFF
--- a/cmd/config.coffee
+++ b/cmd/config.coffee
@@ -17,27 +17,32 @@ limitations under the License.
 # Package modules.
 async   = require 'async'
 chalk   = require 'chalk'
+config  = require 'config'
 program = require 'commander'
 
 # Local modules.
-init    = require '../lib/init.coffee'
-logger  = require '../lib/logger.coffee'
-project = require '../lib/project.coffee'
-user    = require '../lib/user.coffee'
-util    = require '../lib/util.coffee'
+init        = require '../lib/init.coffee'
+logger      = require '../lib/logger.coffee'
+project     = require '../lib/project.coffee'
+user        = require '../lib/user.coffee'
+util        = require '../lib/util.coffee'
+
+initUrl = (host, cb) ->
+  if host? # Format and adjust host.
+    result = util.formatHost host
+    logger.info 'Using host: ' + chalk.cyan result
+    user.host = result
+  else
+    user.host = config.host
+  cb()
 
 # Entry point for the config command.
 module.exports = configure = (host, command, cb) ->
   options = init command # Initialize the command.
 
-  # If host is specified here then set it as the base URL and save it for future requests
-  if host? # Format and adjust host.
-    baasHost = util.formatHost host
-    logger.debug 'Setting host of the Kinvey service to %s', chalk.cyan baasHost
-    user.host = baasHost
-
   # Set-up user and project.
   async.series [
+    (next) -> initUrl        host, next
     (next) -> user.setup     options, next
     (next) -> project.config options, next
   ], (err) ->

--- a/lib/error.coffee
+++ b/lib/error.coffee
@@ -23,6 +23,10 @@ pkg    = require '../package.json'
 
 # Enumerate errors.
 errors =
+  ConnectionError:
+    message: 'The connection to the remote host was unsuccessful. Please try again or contact Kinvey support if the problem persists.'
+  InvalidConfigUrl:
+    message: 'The configuration URL is invalid. Please use a valid Kinvey instance name or URL.'
   InvalidProject:
     message: 'This project is not valid. Please implement the kinvey-flex-sdk node module.'
   ProjectNotConfigured:

--- a/lib/project.coffee
+++ b/lib/project.coffee
@@ -73,8 +73,8 @@ class Project
       if data?.app and data.service # Save ids.
         logger.debug 'Restored project from file %s', chalk.cyan this.projectPath
         this.app           = data.app
-        this.service      = data.service
-        this.serviceName  = data.serviceName
+        this.service       = data.service
+        this.serviceName   = data.serviceName
         this.schemaVersion = data.schemaVersion
         this.lastJobId     = data.lastJobId
         cb()

--- a/lib/user.coffee
+++ b/lib/user.coffee
@@ -70,14 +70,11 @@ class User
   restore: (cb) =>
     logger.debug 'Restoring session from file %s', chalk.cyan this.userPath
     util.readJSON this.userPath, (err, data) =>
+      # If we're reading in config from file
       if data?.host?
         # If `this.host?` at this stage then user has manually updated the host value via the `config` command.
         # Use the new value and neglect the old.
         unless this.host? then this.host = data.host
-      else
-        # If `this.host?` at this stage then user has manually updated the host value via the `config` command.
-        # Use the new value and neglect the default.
-        unless this.host? then this.host = config.host
 
       request.Request = request.Request.defaults { baseUrl: this.host } # Save.
       if data?.tokens? then this.tokens = data.tokens

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -16,11 +16,11 @@ limitations under the License.
 
 # Standard lib.
 fs  = require 'fs'
-url = require 'url'
 
 # Package modules.
-async   = require 'async'
-chalk   = require 'chalk'
+async    = require 'async'
+chalk    = require 'chalk'
+validUrl = require 'valid-url'
 
 # Local modules.
 KinveyError = require './error.coffee'
@@ -30,12 +30,20 @@ user    = require './user.coffee'
 
 # Formats the host argument to be a valid URL.
 exports.formatHost = (host) ->
-  urlObj = url.parse host
-  urlObj = # Make sure the host is correctly set, with protocol and path.
-    host     : urlObj.host     or urlObj.pathname
-    pathname : if urlObj.host? then urlObj.pathname else null
-    protocol : urlObj.protocol or 'https' # Default to HTTPS.
-  url.format urlObj # Return the urlStr.
+  # Check if input host is valid HTTP URI and use it if so
+  validHost = validUrl.isHttpUri host
+  if validHost
+    if validHost.slice(-1) isnt '/' then validHost = validHost + '/'
+    return validHost
+
+  # Check if input host is valid HTTPS URI and use it if so
+  validHost = validHost = validUrl.isHttpsUri host
+  if validHost
+    if validHost.slice(-1) isnt '/' then validHost = validHost + '/'
+    return validHost
+
+  # Input host is neither HTTP or HTTPS. Build host.
+  return 'https://' + host + '-manage.kinvey.com/' # Return the urlStr.
 
 # Formats the provided list for use with inquirer.
 exports.formatList = (list, name = 'name') ->
@@ -61,7 +69,16 @@ exports.makeRequest = makeRequest = (options, cb) ->
   # Perform the request.
   logger.debug 'Request:  %s %s', options.method, options.url
   request.Request options, (err, response) ->
-    if err? then return cb err # Continue with error.
+    connErrors = [ 'ECONNRESET', 'ECONNREFUSED', 'ETIMEDOUT', 'PROTOCOL_CONNECTION_LOST' ]
+    if err?
+      if err.message.indexOf('ENOTFOUND') isnt -1
+        return cb new KinveyError 'InvalidConfigUrl'
+
+      for msg in connErrors
+        if err.message.indexOf(msg) isnt -1
+          return cb new KinveyError 'ConnectionError'
+
+      return cb err # Continue with error.
 
     logger.debug 'Response: %s %s %s', options.method, options.url, chalk.green response.statusCode
     if 2 is parseInt response.statusCode / 100, 10 # OK.

--- a/lib/util.coffee
+++ b/lib/util.coffee
@@ -37,7 +37,7 @@ exports.formatHost = (host) ->
     return validHost
 
   # Check if input host is valid HTTPS URI and use it if so
-  validHost = validHost = validUrl.isHttpsUri host
+  validHost = validUrl.isHttpsUri host
   if validHost
     if validHost.slice(-1) isnt '/' then validHost = validHost + '/'
     return validHost

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "os-homedir": "1.0.1",
     "request": "2.63.0",
     "update-notifier": "0.5.0",
-    "uuid": "2.0.3"
+    "uuid": "2.0.3",
+    "valid-url": "^1.0.9"
   },
   "devDependencies": {
     "chai": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "request": "2.63.0",
     "update-notifier": "0.5.0",
     "uuid": "2.0.3",
-    "valid-url": "^1.0.9"
+    "valid-url": "1.0.9"
   },
   "devDependencies": {
     "chai": "3.3.0",

--- a/test/config.coffee
+++ b/test/config.coffee
@@ -64,7 +64,7 @@ describe "./#{pkg.name} config", () ->
         expect(user.host).to.equal host + '/'
         cb err
 
-  describe 'with a custom HTTP host', () ->
+  describe 'with a custom HTTPS host', () ->
     it 'should configure the project with a custom HTTPS host.', (cb) ->
       host = 'https://host:123/'
       this.config host, command, (err) ->

--- a/test/config.coffee
+++ b/test/config.coffee
@@ -46,12 +46,42 @@ describe "./#{pkg.name} config", () ->
   it 'configure the project with the default host.', (cb) ->
     this.config null, command, (err) ->
       expect(project.config).to.be.calledOnce
-      expect(user.host).to.be.null
+      expect(user.host).to.equal 'https://manage.kinvey.com/'
       cb err
+
+  describe 'with a custom HTTP host', () ->
+    it 'should configure the project.', (cb) ->
+      host = 'http://host:123/'
+      this.config host, command, (err) ->
+        expect(project.config).to.be.calledOnce
+        expect(user.host).to.equal host
+        cb err
+
+    it 'should add a trailing backslash if one is not supplied.', (cb) ->
+      host = 'http://host:123'
+      this.config host, command, (err) ->
+        expect(project.config).to.be.calledOnce
+        expect(user.host).to.equal host + '/'
+        cb err
+
+  describe 'with a custom HTTP host', () ->
+    it 'should configure the project with a custom HTTPS host.', (cb) ->
+      host = 'https://host:123/'
+      this.config host, command, (err) ->
+        expect(project.config).to.be.calledOnce
+        expect(user.host).to.equal host
+        cb err
+
+    it 'should add a trailing backslash if one is not supplied.', (cb) ->
+      host = 'https://host:123'
+      this.config host, command, (err) ->
+        expect(project.config).to.be.calledOnce
+        expect(user.host).to.equal host + '/'
+        cb err
 
   it 'configure the project with a custom host.', (cb) ->
     host = '123'
     this.config host, command, (err) ->
       expect(project.config).to.be.calledOnce
-      expect(user.host).to.equal 'https://' + host
+      expect(user.host).to.equal 'https://' + host + '-manage.kinvey.com/'
       cb err

--- a/test/user.coffee
+++ b/test/user.coffee
@@ -221,7 +221,7 @@ describe 'user', () ->
     it 'should write the token to file.', (cb) ->
       user.save (err) ->
         tokens =
-          host: util.formatHost(config.host)
+          host: null
           tokens:
             abc: '123'
         expect(util.writeJSON).to.be.calledOnce


### PR DESCRIPTION
* `config test` now attempts to configure the CLI using `https://test-manage.kinvey.com`
* HTTP or HTTPS URLs are left in-tact